### PR TITLE
native: cleanup of input and responses

### DIFF
--- a/Dockerfile.build.tpl
+++ b/Dockerfile.build.tpl
@@ -1,0 +1,26 @@
+# Dockerfile.build represents the build environment of the driver, used during
+# the development phase to test and in CI to build and test.
+
+# The prefered base image is the lastest stable Alpine image, if alpine doesn't
+# meet the requirements you can switch the from to the latest stable slim
+# version of Debian (eg.: `debian:jessie-slim`).
+FROM debian:jessie-slim
+
+# To avoid files written in the volume by root or foreign users, we create a
+# container local user with the same UID of the user executing the build.
+# The following commands are defined to use in busybox based distributions,
+# if you are using a standard distributions, replace the `adduser` command with:
+#   `useradd --uid ${BUILD_UID} --home /opt/driver ${BUILD_USER}`
+RUN mkdir -p /opt/driver/src && \
+    useradd --uid ${BUILD_UID} --home /opt/driver ${BUILD_USER}
+
+
+# As minimal build tools you need: make, curl and git, install using the same
+# command the specific tools required to build the driver.
+RUN apt update && \
+    apt install -y --no-install-recommends make git curl ca-certificates
+
+
+# The volume with the full source code is mounted at `/opt/driver/src` so, we
+# set the workdir to this path.
+WORKDIR /opt/driver/src

--- a/Dockerfile.tpl
+++ b/Dockerfile.tpl
@@ -1,0 +1,12 @@
+# Dockerfile represents the container being use to run the driver, should be
+# small as possible containing strictly only the tools required to run the
+# driver.
+
+# The prefered base image is the lastest stable Alpine image, if alpine doesn't
+# meet the requirements you can switch the from to the latest stable slim
+# version of Debian (eg.: `debian:jessie-slim`). If the excution environment
+# is equals to the build environment the build image can be use as FROM:
+#   bblfsh/<language>-driver-build
+FROM debian:jessie-slim
+
+CMD /opt/driver/bin/driver

--- a/README.md
+++ b/README.md
@@ -14,12 +14,13 @@ To initialize the build system execute: `bblfsh-sdk prepare-build`, at the root 
 To execute the tests just execute `make test`, this will execute the test over the native and the go components of the driver. Use `make test-native` to run the test only over the native component or `make test-driver` to run the test just over the go component.
 
 The build is done executing `make build`. To evaluate the result, a docker container, execute:
-`docker run -it bblfsh/java-driver:dev-<commit[:6]>`
+`docker run -it bblfsh/rust-driver:dev-<commit[:6]>`
 
 
 License
 -------
 
 GPLv3, see [LICENSE](LICENSE)
+
 
 


### PR DESCRIPTION
- removes language, language_version and driver from input
- removes language, language_version and driver from output
- instead of sleeping 500ms, return if the len of the line read is 0, it means the stdin has been closed.